### PR TITLE
fix missing `-section` to relevant sections of part4

### DIFF
--- a/discovery/clause_10_hierarchical_collections.adoc
+++ b/discovery/clause_10_hierarchical_collections.adoc
@@ -1,4 +1,4 @@
-[[rc-hierarchical-collections]]
+[[rc-hierarchical-collections-section]]
 == Requirements Class "Hierarchical Collections"
 :sectnums:
 

--- a/discovery/clause_7_searchable_collections.adoc
+++ b/discovery/clause_7_searchable_collections.adoc
@@ -1,4 +1,4 @@
-[[rc-searchable-collections]]
+[[rc-searchable-collections-section]]
 == Requirements Class "Searchable Collections"
 :sectnums:
 

--- a/discovery/clause_8_sortable_collections.adoc
+++ b/discovery/clause_8_sortable_collections.adoc
@@ -1,4 +1,4 @@
-[[rc-sortable-collections]]
+[[rc-sortable-collections-section]]
 == Requirements Class "Sortable Collections"
 :sectnums:
 

--- a/discovery/clause_9_filterable_collections.adoc
+++ b/discovery/clause_9_filterable_collections.adoc
@@ -1,4 +1,4 @@
-[[rc-filterable-collections]]
+[[rc-filterable-collections-section]]
 == Requirements Class "Filtering Collections with CQL2"
 :sectnums:
 


### PR DESCRIPTION
As observed by the list of links at the start of https://docs.ogc.org/DRAFTS/25-046.html#conformance-section, they resolve to a non-existing anchor.