### PR TITLE
add hierarchical collection `parent` link

### DIFF
--- a/discovery/clause_10_hierarchical_collections.adoc
+++ b/discovery/clause_10_hierarchical_collections.adoc
@@ -18,7 +18,7 @@ NOTE: This requirement class does not address the use cases of defining simultan
 Such multiple hierarchies capability could be defined independently (for example, the https://docs.ogc.org/per/18-045.html#hierarchical_paths_extension[`/themes` extension] proposed previously),
 or the use case could be addressed through the `keywords` and/or `themes` core queryable properties defined by _OGC API - Records_ and applicable to the "Searchable Collections" requirement class.
 
-All collections of the hierarchy, whether leaf colections, top-level collections, or anywhere in between, may or may not directly offer access to data using one or more access mechanisms
+All collections of the hierarchy, whether leaf collections, top-level collections, or anywhere in between, may or may not directly offer access to data using one or more access mechanisms
 defined in one or more OGC API data access standards, such as _OGC API - Tiles_, _OGC API - Maps_, _OGC API - Features_ or _OGC API - Coverages_ (or others).
 Those access mechanisms will be included as usual in `links` of the collections.
 
@@ -43,6 +43,13 @@ Although not required, implementations could opt for using a specific character 
 This notably facilitates directly accessing a parent collection in a browser environment by editing URLs in the browser address bar.
 
 CAUTION: Clients cannot rely on the use of any particular separator character to establish the hierarchical relationships between collections. Instead, they need to use the `parent` property specifying the identifier of the parent collection when applicable.
+
+include::recommendations/hierarchical-collections/REC_hierarchical-collection-parent-link.adoc[]
+
+CAUTION: Clients MUST rely on the use of the (<<req_hierarchy_parent-property,`parent` property>>) primarily.
+The corresponding informative `parent` link relation is provided for alignment with other standards such as
+<<https://docs.ogc.org/is/20-004r1/20-004r1.html,OGC API - Records - Part 1: Core>> and
+<<https://github.com/radiantearth/stac-spec/blob/master/commons/links.md,STAC Common Links>>.
 
 In the HTML representation of a collection description resource (`/collections/{collectionId}`), it can be useful to directly show the
 list of children collections, allowing a user to directly click and explore the hierarchy this way.

--- a/discovery/clause_10_hierarchical_collections.adoc
+++ b/discovery/clause_10_hierarchical_collections.adoc
@@ -46,7 +46,7 @@ CAUTION: Clients cannot rely on the use of any particular separator character to
 
 include::recommendations/hierarchical-collections/REC_hierarchical-collection-parent-link.adoc[]
 
-CAUTION: Clients MUST rely on the use of the (<<req_hierarchy_parent-property,`parent` property>>) primarily.
+CAUTION: Clients need to rely on the use of the (<<req_hierarchy_parent-property,`parent` property>>) primarily.
 The corresponding informative `parent` link relation is provided for alignment with other standards such as
 <<https://docs.ogc.org/is/20-004r1/20-004r1.html,OGC API - Records - Part 1: Core>> and
 <<https://github.com/radiantearth/stac-spec/blob/master/commons/links.md,STAC Common Links>>.

--- a/discovery/recommendations/hierarchical-collections/REC_hierarchical-collection-parent-link.adoc
+++ b/discovery/recommendations/hierarchical-collections/REC_hierarchical-collection-parent-link.adoc
@@ -4,7 +4,10 @@
 ====
 [%metadata]
 identifier:: /rec/hierarchical-collections/parent-link
-part:: The implementation SHOULD support a `parent` link relation under the collection description `links`,
-resolving exactly at the location referred by the corresponding `parent` field property,
-to facilitate browsing through the hierarchy directly by URI.
+part:: To facilitate browsing through the hierarchy by following links, the implementation
+SHOULD include a link to the location of the collection description (e.g., `/collections/{parentId}`)
+referred to by the corresponding `parent` property. That link SHOULD be included in the collection's `links`
+using the link relation type `parent`
+(as used for a similar purpose in <<https://docs.ogc.org/is/20-004r1/20-004r1.html,OGC API - Records - Part 1: Core>>
+and <<https://github.com/radiantearth/stac-spec/blob/master/commons/links.md,STAC Common Links>>).
 ====

--- a/discovery/recommendations/hierarchical-collections/REC_hierarchical-collection-parent-link.adoc
+++ b/discovery/recommendations/hierarchical-collections/REC_hierarchical-collection-parent-link.adoc
@@ -5,9 +5,9 @@
 [%metadata]
 identifier:: /rec/hierarchical-collections/parent-link
 part:: To facilitate browsing through the hierarchy by following links, the implementation
-SHOULD include a link to the location of the collection description (e.g., `/collections/{parentId}`)
-referred to by the corresponding `parent` property. That link SHOULD be included in the collection's `links`
-using the link relation type `parent`
-(as used for a similar purpose in <<https://docs.ogc.org/is/20-004r1/20-004r1.html,OGC API - Records - Part 1: Core>>
-and <<https://github.com/radiantearth/stac-spec/blob/master/commons/links.md,STAC Common Links>>).
+SHOULD include a link to the location of the prent collection description (e.g., `/collections/{parentId}`,
+where `{parentId}` is the corresponding `parent` property) in the collection description's `links`
+using the link relation type `parent`. This approach is also used for a similar purpose in
+<<docs.ogc.org/is/20-004r1/20-004r1.html,OGC API - Records - Part 1: Core>>
+and <<radiantearth/stac-spec@master/commons/links.md,STAC Common Links>>
 ====

--- a/discovery/recommendations/hierarchical-collections/REC_hierarchical-collection-parent-link.adoc
+++ b/discovery/recommendations/hierarchical-collections/REC_hierarchical-collection-parent-link.adoc
@@ -1,0 +1,10 @@
+[[rec_hierarchical-collection-parent-link]]
+
+[recommendation]
+====
+[%metadata]
+identifier:: /rec/hierarchical-collections/parent-link
+part:: The implementation SHOULD support a `parent` link relation under the collection description `links`,
+resolving exactly at the location referred by the corresponding `parent` field property,
+to facilitate browsing through the hierarchy directly by URI.
+====


### PR DESCRIPTION
Adds a recommendation to provide `parent` link relation under hierarchical collection.
A caution note is added to indicate that, within the context of *OGC API Common*, the `parent` **property** remains the main reference, but it would be *really smart* to provide the link while at it because all other APIs employ it. 

- relates to https://github.com/radiantearth/stac-spec/pull/1386
- relates to https://github.com/radiantearth/stac-spec/discussions/1374
- relates to https://github.com/opengeospatial/ogcapi-common/issues/386